### PR TITLE
Fixed flex styles so that the images on the onboarding screen work well…

### DIFF
--- a/src/screens/Onboarding/FinalStepScreen/FinalStepScreen.tsx
+++ b/src/screens/Onboarding/FinalStepScreen/FinalStepScreen.tsx
@@ -23,6 +23,8 @@ export default function FinalStepScreen(props: Props) {
         <Text style={styles.content}>
             Explain what you do in one minute or less
         </Text>
+      </View>
+      <View style={styles.header}>
         <Image resizeMode='contain' source={require('../../../../assets/images/finalscreen.png')} />
       </View>
       <View style={styles.footer}>

--- a/src/screens/Onboarding/FinalStepScreen/styles.tsx
+++ b/src/screens/Onboarding/FinalStepScreen/styles.tsx
@@ -4,17 +4,16 @@ const styles = StyleSheet.create({
   container: {
     flex: 1,
     backgroundColor: '#FFFFFF',
+    justifyContent: 'center'
   },
     
   header: {
-    flex: 2,
     display: 'flex',
     flexDirection: 'column',
     alignItems: 'center',
   },
 
   footer: {
-    flex: 1,
     flexDirection: 'column',
     justifyContent: 'center',
     alignItems: 'center',
@@ -29,7 +28,6 @@ const styles = StyleSheet.create({
     width: 301,
     height: 71,
     textAlign: 'center',
-    marginTop: '40%'
   },
 
   content: {
@@ -41,7 +39,6 @@ const styles = StyleSheet.create({
     color: 'black',
     height: 111,
     width: 281,
-    marginBottom: '10%',
   }, 
 
   button: {

--- a/src/screens/Onboarding/StepScreens/StepScreens.tsx
+++ b/src/screens/Onboarding/StepScreens/StepScreens.tsx
@@ -14,38 +14,36 @@ import styles from './styles'
 export default function StepScreens(props: Props) {
   const {navigate} = props.navigation
   const [step, setStep] = useState(2)
-  const [text, setText] = useState('Select questions to answer')
+  const [text, setText] = useState('Select questions to answer\n')
   const [title, setTitle] = useState('Step 1')
-  const [textStyle, setTextStyle] = useState(styles.textOne)
   const [imageSource, setImageSource] = useState(require('../../../../assets/images/step1.png'))
   const [imageSource2, setImageSource2] = useState(require('../../../../assets/images/ellipses1.png'))
 
   return (
     <View style={styles.container}>
       <View style={styles.header}>
-        <Text style={[styles.text, textStyle]}>{text}</Text>
-        <Image resizeMode='contain' source={imageSource} />
+        <Text style={styles.text}>{text}</Text>
+      </View>
+      <View style={styles.header}>
+        <Image resizeMode='contain' source={imageSource}/>
       </View>
       <View style={styles.footer}>
         <TouchableOpacity 
           onPress={() => {
             setStep(step + 1)
             if(step == 2) {
-              setTextStyle(styles.textTwo)
               setText('Record your responses as video snippets')
               setTitle('Step 2')
               setImageSource(require('../../../../assets/images/step2.png'))
               setImageSource2(require('../../../../assets/images/ellipses2.png'))
             }
             if(step == 3) {
-              setTextStyle(styles.textThree)
               setText('Choose snippets to include in your video')
               setTitle('Step 3')
               setImageSource(require('../../../../assets/images/step3.png'))
               setImageSource2(require('../../../../assets/images/ellipses3.png'))
             }
             if(step == 4) {
-              setTextStyle(styles.textFour)
               setText('Create + publish your video to Gladeo\'s Youtube')
               setTitle('Step 4')
               setImageSource(require('../../../../assets/images/step4.png'))

--- a/src/screens/Onboarding/StepScreens/styles.tsx
+++ b/src/screens/Onboarding/StepScreens/styles.tsx
@@ -4,19 +4,21 @@ const styles = StyleSheet.create({
   container: {
     flex: 1,
     backgroundColor: 'white',
+    justifyContent: 'space-evenly',
+    paddingTop: '20%'
   },
     
   header: {
-    flex: 2,
     display: 'flex',
     flexDirection: 'column',
     alignItems: 'center',
+    justifyContent: 'center'
+    
   },
 
   footer: {
-    flex: 1,
     flexDirection: 'column',
-    justifyContent: 'center',
+    justifyContent: 'flex-start',
     alignItems: 'center',
   },
   text: {
@@ -27,32 +29,8 @@ const styles = StyleSheet.create({
     lineHeight: 37,
     textAlign: 'center',
     color: 'black',
-    marginTop: '40%',
+    width: 300
   },
-
-  textOne: {
-    marginBottom: '17%',
-    height: 74,
-    width: 256,
-  }, 
-
-  textTwo: {
-    marginBottom: '13%',
-    height: 111,
-    width: 256,
-  }, 
-
-  textThree: {
-    marginBottom: '12%',
-    height: 111,
-    width: 270,
-  }, 
-
-  textFour: {
-    marginBottom: '10%',
-    height: 111,
-    width: 307,
-  }, 
 
   button: {
     width: 179,
@@ -68,7 +46,7 @@ const styles = StyleSheet.create({
     fontWeight: 'bold',
     color: '#E5186E',
     textAlign: 'center',
-  }
+  },
 })
 
 export default styles


### PR DESCRIPTION
… on (hopefully) all devices. I tested it on iPhone 8 and iPhone X Max, but I don't have an Android simulator, so you might want to test it on your device.

I currently have the final onboarding screen set to `justifyContent: 'center'` but I could change it to `justifyContent: 'space-around'`.  Let me know which one you think looks better.

### center:
![image](https://user-images.githubusercontent.com/35279479/78411970-bc910980-75df-11ea-859d-e144f6548789.png)

### space-around:
![image](https://user-images.githubusercontent.com/35279479/78411999-da5e6e80-75df-11ea-9046-7d58065963d9.png)

### iPhone 8:
![image](https://user-images.githubusercontent.com/35279479/78412043-fcf08780-75df-11ea-9edd-6ee2a0fa8913.png)
![image](https://user-images.githubusercontent.com/35279479/78412052-037eff00-75e0-11ea-987b-5be191af98d7.png)

### iPhone X Max:
![image](https://user-images.githubusercontent.com/35279479/78412066-0c6fd080-75e0-11ea-850d-394661df059e.png)
![image](https://user-images.githubusercontent.com/35279479/78412075-109bee00-75e0-11ea-9fab-7ac894da1fd6.png)
![image](https://user-images.githubusercontent.com/35279479/78412080-1396de80-75e0-11ea-93ec-3c55438d3272.png)
![image](https://user-images.githubusercontent.com/35279479/78412087-15f93880-75e0-11ea-88b8-c9168781b4be.png)
